### PR TITLE
Bug fix for Maven Build Failure PR#65

### DIFF
--- a/version1/processmonitor/derby.log
+++ b/version1/processmonitor/derby.log
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------
-Wed Nov 28 15:08:24 EST 2018:
-Booting Derby version The Apache Software Foundation - Apache Derby - 10.14.2.0 - (1828579): instance a816c00e-0167-5bef-d5cd-000008e18680 
-on database directory memory:D:\kevspace\prjworks\TaskProcessManager\version1\processmonitor\testdb with class loader sun.misc.Launcher$AppClassLoader@18b4aac2 
+Wed Nov 28 16:12:33 EST 2018:
+Booting Derby version The Apache Software Foundation - Apache Derby - 10.14.2.0 - (1828579): instance a816c00e-0167-5c2a-9404-00000d5d5398 
+on database directory memory:D:\kevspace\prjworks\TaskProcessManager\version1\processmonitor\testdb with class loader sun.misc.Launcher$AppClassLoader@6bc7c054 
 Loaded from file:/C:/Users/maristuser/.m2/repository/org/apache/derby/derby/10.14.2.0/derby-10.14.2.0.jar
 java.vendor=Oracle Corporation
 java.runtime.version=1.8.0_181-b13

--- a/version1/processmonitor/src/main/java/corp/tech/vivek/processmonitor/version_info/UtilityPackForVersion.java
+++ b/version1/processmonitor/src/main/java/corp/tech/vivek/processmonitor/version_info/UtilityPackForVersion.java
@@ -28,7 +28,7 @@ public class UtilityPackForVersion {
     /**
      * Trim up to desired decimal places
      *
-     * @param arg
+     * @param places
      * @return trimmed double decimal value
      */
     public static Double getFormattedDecimal(double value, int places) {

--- a/version1/processmonitor/src/test/java/corp/tech/vivek/processmonitor/test/cpu_info/CpuInfoUsageTest.java
+++ b/version1/processmonitor/src/test/java/corp/tech/vivek/processmonitor/test/cpu_info/CpuInfoUsageTest.java
@@ -2,6 +2,7 @@ package corp.tech.vivek.processmonitor.test.cpu_info;
 
 import corp.tech.vivek.processmonitor.cpu_info.CpuInfoUsage;
 import corp.tech.vivek.processmonitor.utility.UtilityPack;
+import org.hyperic.sigar.CpuInfo;
 import org.hyperic.sigar.CpuPerc;
 import org.hyperic.sigar.Sigar;
 import org.hyperic.sigar.SigarException;
@@ -36,7 +37,7 @@ public class CpuInfoUsageTest {
         expectedClassCpuName = new CpuInfoUsage().getClass().getName();
         actualClassCpuName = new CpuInfoUsage().getCpuInfoUsageObject().getClass().getName();
 
-        org.hyperic.sigar.CpuInfo info = UtilityPack.getSigarObject().getCpuInfoList()[0];
+        CpuInfo info = UtilityPack.getSigarObject().getCpuInfoList()[0];
 
         cpuMachineInfoMapTestArg.put("vendor", UtilityPack.getUnkownIfValueNotPresent(info.getVendor()));
         cpuMachineInfoMapTestArg.put("model", UtilityPack.getUnkownIfValueNotPresent(info.getModel()));

--- a/version1/processmonitor/src/test/java/corp/tech/vivek/processmonitor/test/version_info/VersionInfoTest.java
+++ b/version1/processmonitor/src/test/java/corp/tech/vivek/processmonitor/test/version_info/VersionInfoTest.java
@@ -1,14 +1,11 @@
 package corp.tech.vivek.processmonitor.test.version_info;
 
 import corp.tech.vivek.processmonitor.utility.UtilityPack;
-import corp.tech.vivek.processmonitor.version_info.UtilityPackForVersion;
 import corp.tech.vivek.processmonitor.version_info.VersionInfo;
 import org.hyperic.sigar.Sigar;
-import org.hyperic.sigar.SigarException;
 import org.junit.*;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.HashMap;
 
 /**
@@ -34,10 +31,14 @@ public class VersionInfoTest {
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         // setting up the expected values for testing
+        try {
+            expectedHostNameTestArg = InetAddress.getLocalHost().getHostName();
+            expectedFQDNTestArg = new Sigar().getFQDN();
+        } catch (Exception ex) {
+            expectedHostNameTestArg = expectedFQDNTestArg = "unknown";
+        }
 
-        expectedHostNameTestArg = getHostNameForTest();
         expectedUserNameTestArg = System.getProperty("user.name");
-        expectedFQDNTestArg = getFQDNForTest();
 
         expectedOsVersionInfoMap = new HashMap<String, Object>();
         expectedJavaVersionInfoMap = new HashMap<String, Object>();
@@ -118,32 +119,6 @@ public class VersionInfoTest {
     public void tearDown() throws Exception {
         this.verInfoObj = null;
         this.sigarObj.close();
-    }
-
-    /**
-     * Retrieve Host name of the machine
-     *
-     * @return String host name
-     */
-    public static String getHostNameForTest() {
-        try {
-            return InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            return "unknown";
-        }
-    }
-
-    /**
-     * Retrieve Fully Qualified Domain Name of the machine
-     *
-     * @return FQDN
-     */
-    public static String getFQDNForTest() {
-        try {
-            return UtilityPackForVersion.getSigarObject().getFQDN();
-        } catch (SigarException e) {
-            return "unknown";
-        }
     }
 
     /**


### PR DESCRIPTION
fixed the issue by properly importing the required package. But I am not sure this is the actual fix; the issue is with the path not found error for sigar-amd64-winnt.dll